### PR TITLE
Feature/#44

### DIFF
--- a/src/apis/axios.ts
+++ b/src/apis/axios.ts
@@ -40,7 +40,16 @@ export const postLogin = async (email: string, password: string) => {
 		email: email,
 		password: password,
 	});
-	return res.data;
+	return res.data.data;
 };
 
+export const getUserInfo = async () => {
+	const res = await instance.get('members/mypage');
+	return res.data.data;
+};
+
+export const getUserOrderInfo = async () => {
+	const res = await instance.get('members/orders');
+	return res.data;
+};
 export default instance;

--- a/src/components/login/Inner.tsx
+++ b/src/components/login/Inner.tsx
@@ -17,6 +17,7 @@ import { signUpModalState } from 'recoil/atoms/signUpModalAtom';
 import { postLogin } from 'apis/axios';
 import swal from 'sweetalert';
 import { removeCookie, setCookie } from 'utils';
+import { categoryState, dateState } from 'recoil/atoms/myPageAtom';
 
 const Inner = () => {
 	const navigate = useNavigate();
@@ -27,6 +28,8 @@ const Inner = () => {
 	const [showMail, setShowMail] = useState(false);
 	const [showModal, setShowModal] = useState(false);
 	const [modalCheck, setModalCheck] = useRecoilState(signUpModalState);
+	const [category, setCategory] = useRecoilState(categoryState);
+	const [date, setDate] = useRecoilState(dateState);
 	useEffect(() => {
 		setModalCheck(false);
 	}, []);
@@ -65,6 +68,8 @@ const Inner = () => {
 			try {
 				const res = await postLogin(values.mail, values.pw);
 				swal({ title: '로그인에 성공했습니다.', icon: 'success' });
+				setCategory('카테고리 전체');
+				setDate('최근 3개월');
 				const { accessToken } = res;
 				setCookie(accessToken);
 				navigate('/');

--- a/src/components/login/Inner.tsx
+++ b/src/components/login/Inner.tsx
@@ -65,7 +65,7 @@ const Inner = () => {
 			try {
 				const res = await postLogin(values.mail, values.pw);
 				swal({ title: '로그인에 성공했습니다.', icon: 'success' });
-				const { accessToken } = res.data;
+				const { accessToken } = res;
 				setCookie(accessToken);
 				navigate('/');
 			} catch (e: any) {

--- a/src/components/main/Sider.tsx
+++ b/src/components/main/Sider.tsx
@@ -17,7 +17,7 @@ import { Logout, Person, Login } from '@mui/icons-material';
 import { MainSiderProps } from 'types/MainPage.type';
 import SiderRegions from './SiderRegions';
 import { checkAccessToken, logout, removeCookie } from 'utils';
-import swal from 'sweetalert';
+import Swal from 'sweetalert2';
 
 function Sider({ isOpen, handleClose }: MainSiderProps) {
 	const navigate = useNavigate();
@@ -98,26 +98,20 @@ function Sider({ isOpen, handleClose }: MainSiderProps) {
 						const res = checkAccessToken();
 						if (res === false) {
 							removeCookie();
-							swal({
+							Swal.fire({
 								title: '로그인이 필요한 서비스입니다.',
-								text: '로그인 하시겠습니까?',
+								text: '로그인 창으로 이동하시겠습니까?',
 								icon: 'warning',
-								buttons: {
-									confirm: {
-										text: '확인',
-										value: true,
-									},
-									cancel: {
-										text: '취소',
-										value: false,
-										className: 'bg-red',
-									},
-								},
-							}).then((value) => {
-								if (value) {
+								showCancelButton: true,
+								confirmButtonColor: '#3085d6',
+								cancelButtonColor: '#d33',
+								confirmButtonText: '확인',
+								cancelButtonText: '취소',
+							}).then((result) => {
+								if (result.isConfirmed) {
 									navigate('/login');
 								} else {
-									navigate('/');
+									Swal.close();
 								}
 							});
 						} else {

--- a/src/components/main/Sider.tsx
+++ b/src/components/main/Sider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import {
 	Drawer,
@@ -18,11 +18,14 @@ import { MainSiderProps } from 'types/MainPage.type';
 import SiderRegions from './SiderRegions';
 import { checkAccessToken, logout, removeCookie } from 'utils';
 import Swal from 'sweetalert2';
+import { useRecoilState } from 'recoil';
+import { categoryState, dateState } from 'recoil/atoms/myPageAtom';
 
 function Sider({ isOpen, handleClose }: MainSiderProps) {
 	const navigate = useNavigate();
 	const [isAccessToken, setIsAccessToken] = useState(checkAccessToken());
-
+	const [category, setCategory] = useRecoilState(categoryState);
+	const [date, setDate] = useRecoilState(dateState);
 	return (
 		<Drawer
 			placement="left"
@@ -128,6 +131,8 @@ function Sider({ isOpen, handleClose }: MainSiderProps) {
 					<ListItem
 						onClick={() => {
 							logout();
+							setCategory('카테고리 전체');
+							setDate('최근 3개월');
 							setIsAccessToken(checkAccessToken());
 						}}
 					>

--- a/src/components/myPage/Inner.tsx
+++ b/src/components/myPage/Inner.tsx
@@ -3,7 +3,7 @@ import bannerRed from '../../assets/images/bannerRed.png';
 import { ArrowDropDown } from '@mui/icons-material';
 import CategoryModal from './CategoryModal';
 import DateModal from './DateModal';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { categoryState, dateState } from 'recoil/atoms/myPageAtom';
 import ReservationCard from './ReservationCard';
 import { logout } from 'utils';
@@ -18,13 +18,15 @@ const Inner = () => {
 	const [email, setEmail] = useState('');
 	const nowCategory = useRecoilValue(categoryState);
 	const nowDate = useRecoilValue(dateState);
+	const [category, setCategory] = useRecoilState(categoryState);
+	const [date, setDate] = useRecoilState(dateState);
+
 	const handleCategoryModalClose = () => {
 		setShowCategoryModal(false);
 	};
 	const handleDateModalClose = () => {
 		setShowDateModal(false);
 	};
-
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
@@ -51,6 +53,8 @@ const Inner = () => {
 						className="text-xxsm text-textGray cursor-pointer"
 						onClick={() => {
 							logout();
+							setCategory('카테고리 전체');
+							setDate('최근 3개월');
 							navigate('/');
 						}}
 					>

--- a/src/components/myPage/Inner.tsx
+++ b/src/components/myPage/Inner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import bannerRed from '../../assets/images/bannerRed.png';
 import { ArrowDropDown } from '@mui/icons-material';
 import CategoryModal from './CategoryModal';
@@ -8,11 +8,14 @@ import { categoryState, dateState } from 'recoil/atoms/myPageAtom';
 import ReservationCard from './ReservationCard';
 import { logout } from 'utils';
 import { useNavigate } from 'react-router-dom';
+import { getUserInfo } from 'apis/axios';
 
 const Inner = () => {
 	const navigate = useNavigate();
 	const [showCategoryModal, setShowCategoryModal] = useState(false);
 	const [showDateModal, setShowDateModal] = useState(false);
+	const [name, setName] = useState('');
+	const [email, setEmail] = useState('');
 	const nowCategory = useRecoilValue(categoryState);
 	const nowDate = useRecoilValue(dateState);
 	const handleCategoryModalClose = () => {
@@ -21,12 +24,27 @@ const Inner = () => {
 	const handleDateModalClose = () => {
 		setShowDateModal(false);
 	};
+
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const res = await getUserInfo();
+				const { email, name } = res;
+				setName(name);
+				setEmail(email);
+			} catch (e) {
+				console.log(e);
+			}
+		};
+		fetchData();
+	}, []);
+
 	return (
 		<div className="pt-20 min-h-screen m-auto bg-white max-w-[768px] mx-auto">
 			<div className="pt-4.5 pl-6 pr-6 pb-7">
 				<div className="flex justify-between items-center">
 					<div className="text-content font-bold text-black cursor-default">
-						여기에 사용자 이름
+						{name}
 					</div>
 
 					<div
@@ -39,9 +57,7 @@ const Inner = () => {
 						로그아웃
 					</div>
 				</div>
-				<div className="text-md text-textGray pt-3 cursor-default">
-					여기에 사용자 이메일
-				</div>
+				<div className="text-md text-textGray pt-3 cursor-default">{email}</div>
 				<div className="mt-[48px]">
 					<img
 						src={bannerRed}

--- a/src/pages/myPage/index.tsx
+++ b/src/pages/myPage/index.tsx
@@ -1,7 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Header from 'components/myPage/Header';
 import Inner from 'components/myPage/Inner';
+import { useNavigate } from 'react-router-dom';
+import { getCookie } from 'utils';
+import swal from 'sweetalert';
 const MyPage = () => {
+	const navigate = useNavigate();
+	useEffect(() => {
+		const accessToken = getCookie('accessToken');
+		if (!accessToken) {
+			swal({ title: '로그인이 필요한 서비스입니다.', icon: 'warning' });
+			navigate('/');
+		}
+	}, []);
 	return (
 		<div className="min-h-screen bg-bgGray">
 			<Header />

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import swal from 'sweetalert';
 
 export const handleArrowBackClick = () => {
@@ -33,6 +32,7 @@ export const removeCookie = async () => {
 
 export const logout = () => {
 	removeCookie();
+
 	swal({ title: '로그아웃에 성공했습니다.', icon: 'success' });
 };
 


### PR DESCRIPTION
## 관련 이슈
close #44 
close #45 
close #43 
close #46 

## Description
로그인
회원가입
리다이렉션
-> 로그아웃인 상태로 /mypage접근 시 block
-> 로그아웃인 상태로 사이드 바의 마이페이지 클릭 시 로그인 관련 swal모달 팝업
     -> 확인 누르면 로그인 페이지로, 취소 누르면 모달 닫기
-> 로그인 상태로 /login접근 시 block
로그아웃
사이드 바 동적 라우팅
-> 사이드 바에서 로그아웃 기능 수행 시 자동으로 로그인으로 변경(버튼)
마이페이지 내 유저 아이디 및 유저 이메일 연동

## 유의할 점 및 ETC (optional)
npm i!